### PR TITLE
GetIndexOf should conform to Regex-style result #1

### DIFF
--- a/common.go
+++ b/common.go
@@ -33,6 +33,7 @@ func GetIndexOf(text string, pattern string) []int{
 	for counter:=0; counter<=len(text)-length; counter++{
 		if string(text[counter:counter+length])==pattern{
 			positions = append(positions, counter)
+			counter += length-1
 		}
 	}
 	return positions


### PR DESCRIPTION
The simple fix in `GetIndexOf()` was to move the indexing `counter` to the end of a pattern match i.e. to it's current value + `length`
This solves #1 
Testing can be found inside the issue